### PR TITLE
[이원국] [공용 컴포넌트] 알림 모달창 구현 및 카트 페이지 탑재

### DIFF
--- a/src/components/Modal/AlertModal.js
+++ b/src/components/Modal/AlertModal.js
@@ -1,0 +1,28 @@
+import { Component } from 'react';
+import './AlertModal.scss';
+
+export default class AlertModal extends Component {
+  render() {
+    const { visibility, closeModal, headerTxt, message, confirmMsg } =
+      this.props;
+    return (
+      <div className={`AlertModal ${visibility ? '' : 'hidden'}`}>
+        <div className='overlay' onClick={closeModal}></div>
+        <div className='window'>
+          <div className='main'>
+            <div className='header'>
+              <h2>{headerTxt}</h2>
+              <button className='closeBtn' onClick={closeModal}></button>
+            </div>
+            <div className='message'>{message}</div>
+          </div>
+          <div className='footer'>
+            <button className='confirmBtn' onClick={closeModal}>
+              {confirmMsg}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/Modal/AlertModal.scss
+++ b/src/components/Modal/AlertModal.scss
@@ -1,0 +1,81 @@
+@import '../../styles/variables';
+
+.AlertModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+
+  &.hidden {
+    display: none;
+  }
+
+  .overlay {
+    height: 100vh;
+    width: 100vw;
+    background-color: rgba($color: #000000, $alpha: 0.5);
+  }
+
+  .window {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    width: 490px;
+    background-color: #ffffff;
+    text-align: center;
+    transform: translate(-50%, -50%);
+
+    button {
+      cursor: pointer;
+    }
+
+    .main {
+      padding: 25px;
+
+      .header {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 25px;
+        padding-bottom: 15px;
+        border-bottom: 1px solid #b2b2b2;
+
+        h2 {
+          color: $themeColorPrimary;
+          line-height: 24px;
+          font-size: 16px;
+          font-weight: 500;
+        }
+
+        .closeBtn {
+          height: 20px;
+          width: 20px;
+          background: none;
+          border: none;
+          background-image: url('https://res.kurly.com/pc/etc/old/images/common/icon-close-button.png');
+          background-repeat: no-repeat;
+          background-size: 20px 20px;
+          background-position: center;
+        }
+      }
+
+      .message {
+        height: 60px;
+        font-size: 14px;
+        line-height: 60px;
+      }
+    }
+
+    .footer {
+      padding: 30px;
+      background-color: #f5f5f5;
+
+      .confirmBtn {
+        height: 43px;
+        width: 148px;
+        color: #ffffff;
+        background-color: $themeColorPrimary;
+        border: none;
+      }
+    }
+  }
+}

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import ItemField from './ItemField';
 import CartResult from './CartResult';
+import AlertModal from '../../components/Modal/AlertModal';
 import './Cart.scss';
 
 export default class Cart extends Component {
@@ -15,6 +16,7 @@ export default class Cart extends Component {
       selectAll: true,
       userAddress: '',
       topCoords: 60,
+      modalVisibility: false,
     };
     this.window = null;
   }
@@ -179,6 +181,10 @@ export default class Cart extends Component {
   };
 
   deleteSelectedItems = async () => {
+    if (!this.state.checkedItems.length) {
+      this.setState({ modalVisibility: true });
+      return;
+    }
     const deleteConsent = window.confirm('선택한 상품을 삭제하시겠습니까?');
     if (!deleteConsent) return;
     const selected = [...this.state.checkedItems].map(ele => ele.id);
@@ -284,6 +290,13 @@ export default class Cart extends Component {
     const currentQuantity = event.target.parentNode.children[1].textContent * 1;
     if (currentQuantity <= 1) return;
     this.manipulateQuantities(currentTarget, -1);
+  };
+
+  closeModal = e => {
+    e.preventDefault();
+    this.setState({
+      modalVisibility: false,
+    });
   };
 
   render() {
@@ -410,6 +423,13 @@ export default class Cart extends Component {
             </form>
           </div>
         </div>
+        <AlertModal
+          headerTxt='알림메세지'
+          message='삭제할 상품을 선택해주세요.'
+          confirmMsg='확인'
+          visibility={this.state.modalVisibility}
+          closeModal={this.closeModal}
+        />
       </section>
     );
   }


### PR DESCRIPTION
# 구현 내용
![스크린샷 2021-10-17 오후 8 33 23](https://user-images.githubusercontent.com/61101022/137625629-2d9090da-a3da-44ae-8148-bb21c907cbc9.png)

유저가 잘못된 입력을 했을때 주의를 끌기 위한 Alert Modal Interaction 컴포넌트입니다.
사용법은 아래와 같습니다.

## 사용 방법

### 추가해야 할 State
모달 컴포넌트를 사용할 `부모 컴포넌트`에 아래의 코드를 추가해주세요.
이는 UI State를 부모 컴포넌트에서 관리하기 위함입니다.

1. modalVisibility 상태 추가 (기본값 false)
```
modalVisibility: false
```

2. 모달창이 열리는 로직 추가
모달창이 열리는 버튼 또는 로직에 가시성 상태를 변경하는 로직을 추가하십시오.
```
if (!this.state.checkedItems.length) {
  this.setState({ modalVisibility: true });
  return;
}
```

3. closeModal 메소드 추가
```
closeModal = e => {
  e.preventDefault();
    this.setState({
    modalVisibility: false,
  });
};
```

### 전달되어야 할 Props

- headerTxt : 좌측 상단에 모달의 명칭을 표시
- message : 모달창에 표시될 메세지
- confirmMsg : 완료 버튼에 표시될 텍스트
- visibility (State)
- closeModal (Method)

```
<AlertModal
  headerTxt='알림메세지'
  message='삭제할 상품을 선택해주세요.'
  confirmMsg='확인'
  visibility={this.state.modalVisibility}
  closeModal={this.closeModal}
/>
```