### PR TITLE
[이원국] [버그] 장바구니에서 제품 상세페이지 이동 기능 정상화 및 페이지 스위칭시 스크롤 초기화

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import ScrollToTop from './utils/ScrollToTop';
 import TopNav from './components/Nav/TopNav';
 import Footer from './components/Footer/Footer';
 import Detail from './pages/Detail/Detail';
@@ -14,17 +15,19 @@ class Routes extends React.Component {
   render() {
     return (
       <Router>
-        <Route component={TopNav} />
-        <Switch>
-          <Route exact path='/' component={Main} />
-          <Route exact path='/login' component={Login} />
-          <Route exact path='/signup' component={SignUp} />
-          <Route exact path='/detail/:id' component={Detail} />
-          <Route exact path='/cart' component={Cart}></Route>
-          <Route exact path='/findaccount' component={FindAccount} />
-          <Route exact path='/findpw' component={FindPw} />
-        </Switch>
-        <Route component={Footer} />
+        <ScrollToTop>
+          <TopNav />
+          <Switch>
+            <Route exact path='/' component={Main} />
+            <Route exact path='/login' component={Login} />
+            <Route exact path='/signup' component={SignUp} />
+            <Route exact path='/detail/:id' component={Detail} />
+            <Route exact path='/cart' component={Cart}></Route>
+            <Route exact path='/findaccount' component={FindAccount} />
+            <Route exact path='/findpw' component={FindPw} />
+          </Switch>
+          <Footer />
+        </ScrollToTop>
       </Router>
     );
   }

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -38,10 +38,6 @@ export default class Cart extends Component {
     }
   };
 
-  goToDetailPage = id => {
-    this.props.history.push(`/detail/${id}`);
-  };
-
   componentDidMount() {
     window.addEventListener('scroll', this.autoScrolling);
     fetch('http://localhost:8000/cart', {
@@ -345,7 +341,6 @@ export default class Cart extends Component {
                     deleteOneItem={this.deleteOneItem}
                     decreaseQuantity={this.decreaseQuantity}
                     increaseQuantity={this.increaseQuantity}
-                    goToDetailPage={this.goToDetailPage}
                   />
                 ) : null}
                 {this.state.cartData.filter(
@@ -361,7 +356,6 @@ export default class Cart extends Component {
                     deleteOneItem={this.deleteOneItem}
                     decreaseQuantity={this.decreaseQuantity}
                     increaseQuantity={this.increaseQuantity}
-                    goToDetailPage={this.goToDetailPage}
                   />
                 ) : null}
                 {this.state.cartData.filter(
@@ -380,7 +374,6 @@ export default class Cart extends Component {
                     deleteOneItem={this.deleteOneItem}
                     decreaseQuantity={this.decreaseQuantity}
                     increaseQuantity={this.increaseQuantity}
-                    goToDetailPage={this.goToDetailPage}
                   />
                 ) : null}
                 {!this.state.cartData.length ? (

--- a/src/pages/Cart/Item.js
+++ b/src/pages/Cart/Item.js
@@ -6,6 +6,7 @@ export default class Item extends Component {
   render() {
     const {
       productId,
+      checkedItems,
       name,
       sales_price,
       original_price,
@@ -20,13 +21,7 @@ export default class Item extends Component {
           onClick={this.props.checkingItems.bind(this, productId)}
         ></span>
         <picture className='itemThumb'>
-          <Link
-            to='/'
-            onClick={event => {
-              event.preventDefault();
-              this.props.goToDetailPage(productId);
-            }}
-          >
+          <Link to={`/detail/${checkedItems.product_id}`}>
             <img src={thumbnail_image} alt={name} />
           </Link>
         </picture>

--- a/src/pages/Cart/ItemField.js
+++ b/src/pages/Cart/ItemField.js
@@ -79,7 +79,6 @@ export default class ItemField extends Component {
                 decreaseQuantity={this.props.decreaseQuantity}
                 increaseQuantity={this.props.increaseQuantity}
                 original_price={original_price}
-                goToDetailPage={this.props.goToDetailPage}
               />
             );
           })}

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import MainBanner from './components/MainBanner/MainBanner';
 import Section from './components/Section';
 import SpecialPrice from './components/SpecialPrice';

--- a/src/utils/ScrollToTop.js
+++ b/src/utils/ScrollToTop.js
@@ -1,0 +1,14 @@
+import { PureComponent } from 'react';
+import { withRouter } from 'react-router-dom';
+
+class ScrollIntoTop extends PureComponent {
+  componentDidMount = () => window.scrollTo(0, 0);
+
+  componentDidUpdate = prevProps => {
+    if (this.props.location !== prevProps.location) window.scrollTo(0, 0);
+  };
+
+  render = () => this.props.children;
+}
+
+export default withRouter(ScrollIntoTop);


### PR DESCRIPTION
# Self-Refactoring 체크리스트

> [Pre-Course 리팩토링 체크리스트](https://www.notion.so/wecode/Pre-Course-Refactoring-869f50bf6a934db98573229c600043ee)를 참고하여 리팩토링 진행해주세요.

> [Foundation Frontend 리팩토링 체크리스트](https://www.notion.so/wecode/Foundation-Frontend-Refactoring-85e629d7a22841b2bd4917c9c72a1f58)를 참고하여 리팩토링을 진행한 항목에 대해 체크를 해주세요.

- [ ] 0. Pre-Course 리팩토링 체크리스트 리팩토링 완료
- [ ] 1. reset.scss & common.scss
- [ ] 2. sass nesting 완료
- [ ] 3. className 동적 활용
- [ ] 4. destructuring
- [ ] 5. Boolean 데이터 타입 활용
- [ ] 6. 반복되는 코드 Array.map() 활용
- [ ] 7. 계산된 속성명 활용
- [ ] 8. \<a\>와 \<Link\> 구분하여 사용
- [ ] 9. import 순서

# Peer Reviews

- [ ] Peer Reviews 받기 완료
